### PR TITLE
DWH-788: Multi-cluster support

### DIFF
--- a/dbt/adapters/clickhouse/credentials.py
+++ b/dbt/adapters/clickhouse/credentials.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Literal, Optional, Union
 
 from dbt.adapters.contracts.connection import Credentials
 from dbt_common.exceptions import DbtRuntimeError
@@ -20,9 +20,9 @@ class ClickHouseCredentials(Credentials):
     schema: Optional[str] = 'default'
     password: str = ''
     cluster: Optional[str] = None
-    remote_clusters: Optional[list[str]] = None
     database_engine: Optional[str] = None
     cluster_mode: bool = False
+    remote_clusters: Optional[list[dict[Literal['name', 'database_engine'], str]]] = None
     secure: bool = False
     verify: bool = True
     connect_timeout: int = 10

--- a/dbt/adapters/clickhouse/credentials.py
+++ b/dbt/adapters/clickhouse/credentials.py
@@ -20,6 +20,7 @@ class ClickHouseCredentials(Credentials):
     schema: Optional[str] = 'default'
     password: str = ''
     cluster: Optional[str] = None
+    remote_clusters: Optional[list[str]] = None
     database_engine: Optional[str] = None
     cluster_mode: bool = False
     secure: bool = False

--- a/dbt/adapters/clickhouse/errors.py
+++ b/dbt/adapters/clickhouse/errors.py
@@ -49,3 +49,9 @@ The clusters: {0} are not known to the current host, but are configured as `remo
 Either add the cluster name to the remote_servers section of your ClickHouse config.xml, or remove the entries from the
 `remote_clusters` section of your dbt configuration.
 """
+
+remote_cluster_without_name = """
+The `name` attribute of a remote cluster in the `remote_clusters` profile section is missing.
+
+   Remote cluster section: {0}
+"""

--- a/dbt/adapters/clickhouse/errors.py
+++ b/dbt/adapters/clickhouse/errors.py
@@ -43,3 +43,9 @@ The setting `allow_nondeterministic_mutations` is not enabled and is `read_only`
 of `light weight deletes` and therefore the delete+insert incremental strategy.  This may negatively affect performance
 for incremental models
 """
+
+remote_cluster_not_known_by_host = """
+The clusters: {0} are not known to the current host, but are configured as `remote_clusters` in the dbt configuration.
+Either add the cluster name to the remote_servers section of your ClickHouse config.xml, or remove the entries from the
+`remote_clusters` section of your dbt configuration.
+"""

--- a/dbt/adapters/clickhouse/impl.py
+++ b/dbt/adapters/clickhouse/impl.py
@@ -121,9 +121,16 @@ class ClickHouseAdapter(SQLAdapter):
             return f'"{conn.credentials.cluster}"'
 
     @available.parse(lambda *a, **k: {})
-    def get_clickhouse_remote_clusters(self) -> Optional[list[str]]:
+    def get_clickhouse_remote_clusters(self, add_to_remote_clusters: Optional[bool]) -> Optional[list[str]]:
+        if not add_to_remote_clusters:
+            return
         conn = self.connections.get_if_exists()
-        return conn.credentials.remote_clusters
+        remote_clusters = conn.credentials.remote_clusters
+        if not remote_clusters:
+            raise DbtRuntimeError(
+                '`add_to_remote_clusters` is set for the model, but no `remote_clusters` are defined via credentials!'
+            )
+        return remote_clusters
 
     @available.parse(lambda *a, **k: {})
     def get_clickhouse_local_suffix(self):

--- a/dbt/adapters/clickhouse/impl.py
+++ b/dbt/adapters/clickhouse/impl.py
@@ -121,6 +121,11 @@ class ClickHouseAdapter(SQLAdapter):
             return f'"{conn.credentials.cluster}"'
 
     @available.parse(lambda *a, **k: {})
+    def get_clickhouse_remote_clusters(self) -> Optional[list[str]]:
+        conn = self.connections.get_if_exists()
+        return conn.credentials.remote_clusters
+
+    @available.parse(lambda *a, **k: {})
     def get_clickhouse_local_suffix(self):
         conn = self.connections.get_if_exists()
         suffix = conn.credentials.local_suffix

--- a/dbt/adapters/clickhouse/relation.py
+++ b/dbt/adapters/clickhouse/relation.py
@@ -44,6 +44,7 @@ class ClickHouseRelation(BaseRelation):
     quote_character: str = '`'
     can_exchange: bool = False
     can_on_cluster: bool = False
+    remote_cluster: Optional[str] = None
 
     def __post_init__(self):
         if self.database != self.schema and self.database:

--- a/dbt/include/clickhouse/macros/adapters.sql
+++ b/dbt/include/clickhouse/macros/adapters.sql
@@ -9,7 +9,7 @@
   {%- call statement('create_schema') -%}
     create database if not exists {{ relation.without_identifier().include(database=False) }}
         {{ on_cluster_clause(relation)}}
-        {{ adapter.clickhouse_db_engine_clause() }}
+        {{ adapter.clickhouse_db_engine_clause(relation) }}
   {% endcall %}
 {% endmacro %}
 

--- a/dbt/include/clickhouse/macros/materializations/distributed_table.sql
+++ b/dbt/include/clickhouse/macros/materializations/distributed_table.sql
@@ -87,10 +87,10 @@
 {% endmaterialization %}
 
 {% macro create_distributed_table(relation, local_relation) %}
-    {%- set cluster = adapter.get_clickhouse_cluster_name() -%}
+   {%- set cluster = adapter.get_clickhouse_cluster_name() -%}
    {% if cluster is none %}
-        {% do exceptions.raise_compiler_error('Cluster name should be defined for using distributed materializations, current is None') %}
-    {% endif %}
+      {% do exceptions.raise_compiler_error('Cluster name should be defined for using distributed materializations, current is None') %}
+   {% endif %}
 
    {%- set cluster = cluster[1:-1] -%}
    {%- set sharding = config.get('sharding_key') -%}

--- a/dbt/include/clickhouse/macros/materializations/distributed_table.sql
+++ b/dbt/include/clickhouse/macros/materializations/distributed_table.sql
@@ -79,6 +79,15 @@
 
   {% do persist_docs(target_relation, model) %}
   {{ run_hooks(post_hooks, inside_transaction=True) }}
+
+  {% if remote_clusters %}
+    {% for remote_cluster in remote_clusters %}
+      {% set remote_relation = target_relation.incorporate(remote_cluster=remote_cluster.get('name')) %}
+      {% do create_schema(remote_relation) %}
+      {% do run_query(create_distributed_table(remote_relation, target_relation_local)) %}
+    {% endfor %}
+  {% endif %}
+
   {{ adapter.commit() }}
   {{ drop_relation_if_exists(backup_relation) }}
   {{ run_hooks(post_hooks, inside_transaction=False) }}

--- a/dbt/include/clickhouse/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/clickhouse/macros/materializations/incremental/incremental.sql
@@ -112,11 +112,11 @@
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 
   {% if remote_clusters %}
-     {% for remote_cluster in remote_clusters %}
-       {% set remote_relation = target_relation.incorporate(remote_cluster=remote_cluster) %}
-       {% do create_schema(remote_relation) %}
-       {% do run_query(create_distributed_table(remote_relation, target_relation)) %}
-     {% endfor %}
+    {% for remote_cluster in remote_clusters %}
+      {% set remote_relation = target_relation.incorporate(remote_cluster=remote_cluster.get('name')) %}
+      {% do create_schema(remote_relation) %}
+      {% do run_query(create_distributed_table(remote_relation, target_relation)) %}
+    {% endfor %}
   {% endif %}
 
   {% do adapter.commit() %}

--- a/dbt/include/clickhouse/macros/materializations/table.sql
+++ b/dbt/include/clickhouse/macros/materializations/table.sql
@@ -129,9 +129,9 @@
 
 {% macro on_cluster_clause(relation, force_sync) %}
   {% set active_cluster = adapter.get_clickhouse_cluster_name() %}
-  {%- if active_cluster is not none and relation.should_on_cluster %}
+  {%- if (active_cluster is not none and relation.should_on_cluster) or relation.remote_cluster %}
     {# Add trailing whitespace to avoid problems when this clause is not last #}
-    ON CLUSTER {{ active_cluster + ' ' }}
+    ON CLUSTER {{ relation.remote_cluster or active_cluster }}
     {%- if force_sync %}
     SYNC
     {%- endif %}

--- a/dbt/include/clickhouse/macros/materializations/table.sql
+++ b/dbt/include/clickhouse/macros/materializations/table.sql
@@ -56,6 +56,14 @@
 
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 
+  {% if remote_clusters %}
+    {% for remote_cluster in remote_clusters %}
+      {% set remote_relation = target_relation.incorporate(remote_cluster=remote_cluster.get('name')) %}
+      {% do create_schema(remote_relation) %}
+      {% do run_query(create_distributed_table(remote_relation, target_relation)) %}
+    {% endfor %}
+  {% endif %}
+
   {{ adapter.commit() }}
 
   {{ drop_relation_if_exists(backup_relation) }}

--- a/tests/integration/adapter/remote_clusters/test_remote_distributed_tables.py
+++ b/tests/integration/adapter/remote_clusters/test_remote_distributed_tables.py
@@ -1,0 +1,65 @@
+import pytest
+from dbt.tests.util import run_dbt
+
+base_model = """
+{{
+    config(
+        materialized='%s',
+        order_by='number',
+        unique_key='number',
+        add_to_remote_cluster=True,
+    )
+}}
+select number from numbers(3)
+"""
+
+
+class TestRemoteDistributedTable:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental_model.sql": base_model % "incremental",
+            "distributed_incremental_model.sql": base_model % "distributed_incremental",
+            "table_model.sql": base_model % "table",
+            "distributed_table_model.sql": base_model % "distributed_table",
+            "view_model.sql": base_model % "view",
+            "materialized_view_model.sql": base_model % "materialized_view",
+        }
+
+    @pytest.fixture(scope="class")
+    def hosts(self, project):
+        remote_clusters = project.test_config['remote_clusters']
+        hosts = project.run_sql(
+            f"select host_name from system.clusters where cluster in (`{"`,`".join(remote_clusters)}`)",
+            fetch="all",
+        )
+        assert len(hosts) >= 1
+        return hosts
+
+    @pytest.mark.parametrize(
+        "model",
+        (
+            "incremental_model",
+            "distributed_incremental_model",
+            "table_model",
+            "distributed_table_model",
+            "view_model",
+            "materialized_view_model",
+        )
+    )
+    def test_incremental(self, project, hosts, model):
+        run_dbt(["run", "--select", model])
+        for host in hosts:
+            # check for correct table engine
+            result = project.run_sql(
+                f"select engine from remote('{host}','system.tables' where name='{model}')",
+                fetch="one"
+            )
+            assert result[0] == "Distributed"
+            # check for correct data query results
+            result = project.run_sql(
+                f"select number from remote('{host}','{model}') order by number",
+                fetch="all",
+            )
+            assert len(result[0]) == 3
+            assert result[0] == [1, 2, 3]

--- a/tests/integration/adapter/remote_clusters/test_remote_distributed_tables.py
+++ b/tests/integration/adapter/remote_clusters/test_remote_distributed_tables.py
@@ -15,29 +15,26 @@ select number from numbers(3)
 """
 
 
-class TestRemoteDistributedTable:
+class TestRemoteTable:
     @pytest.fixture(scope="class")
     def models(self):
         return {
             "incremental_model.sql": base_model % "incremental",
-            "distributed_incremental_model.sql": base_model % "distributed_incremental",
             "table_model.sql": base_model % "table",
-            "distributed_table_model.sql": base_model % "distributed_table",
-            "view_model.sql": base_model % "view",
-            "materialized_view_model.sql": base_model % "materialized_view",
         }
 
     @pytest.fixture(scope="class")
     def test_config(self, test_config):
-        """Chaining test_config fixture to modify db_engine for this test."""
+        """Patching test_config fixture to modify db_engine for this test."""
         test_config["db_engine"] = "Replicated('/clickhouse/databases/{uuid}', '{shard}', '{replica}')"
         return test_config
 
     @pytest.fixture(scope="class")
     def remote_hosts(self, project):
-        remote_clusters = project.test_config['remote_clusters']
+        remote_clusters = project.test_config.get('remote_clusters', [])
+        remote_cluster_names = [cluster.get('name') for cluster in remote_clusters]
         hosts = project.run_sql(
-            f"select host_name from system.clusters where cluster in ('{"','".join(remote_clusters)}')",
+            f"select host_name from system.clusters where cluster in ('{"','".join(remote_cluster_names)}')",
             fetch="all",
         )
         assert len(hosts[0]) >= 1
@@ -47,17 +44,61 @@ class TestRemoteDistributedTable:
         "model",
         (
             "incremental_model",
-            # "distributed_incremental_model",
-            # "table_model",
-            # "distributed_table_model",
-            # "view_model",
-            # "materialized_view_model",
+            "table_model",
         )
     )
     @pytest.mark.skipif(
         os.environ.get('DBT_CH_TEST_REMOTE_CLUSTERS', '').strip() == '', reason='No remote clusters'
     )
-    def test_replicated_db(self, project, remote_hosts, model):
+    def test_remote_table(self, project, remote_hosts, model):
+        run_dbt(["run", "--select", model])
+        for host in remote_hosts:
+            # check for correct table creation
+            result = project.run_sql(
+                f"select engine from remote('{host}','system.tables') where name='{model}'",
+                fetch="one"
+            )
+            assert result is not None
+            assert result[0] == "Distributed"
+            # check for correct data query results
+            result = project.run_sql(
+                f"select number from remote('{host}','{project.test_schema}','{model}') order by number",
+                fetch="all",
+            )
+            assert len(result[0]) == 3
+            assert result[0] == [0, 1, 2]
+
+
+class TestRemoteTableDistributedMaterialization:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "distributed_incremental_model.sql": base_model % "distributed_incremental",
+            "distributed_table_model.sql": base_model % "distributed_table",
+        }
+
+    @pytest.fixture(scope="class")
+    def remote_hosts(self, project):
+        remote_clusters = project.test_config.get('remote_clusters', [])
+        remote_cluster_names = [cluster.get('name') for cluster in remote_clusters]
+        hosts = project.run_sql(
+            f"select host_name from system.clusters where cluster in ('{"','".join(remote_cluster_names)}')",
+            fetch="all",
+        )
+        assert len(hosts[0]) >= 1
+        return hosts[0]
+
+    @pytest.mark.parametrize(
+        "model",
+        (
+                "distributed_incremental_model",
+                "distributed_table_model",
+        )
+    )
+    @pytest.mark.skipif(
+        os.environ.get('DBT_CH_TEST_REMOTE_CLUSTERS', '').strip() == '', reason='No remote clusters'
+    )
+    def test_remote_table(self, project, remote_hosts, model):
         run_dbt(["run", "--select", model])
         for host in remote_hosts:
             # check for correct table creation

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -38,7 +38,8 @@ def test_config(ch_test_users, ch_test_version):
     test_user = os.environ.get('DBT_CH_TEST_USER', 'default')
     test_password = os.environ.get('DBT_CH_TEST_PASSWORD', '')
     test_cluster = os.environ.get('DBT_CH_TEST_CLUSTER', '')
-    test_remote_clusters = os.environ.get('DBT_CH_TEST_REMOTE_CLUSTERS', '').split(',')
+    test_remote_clusters = [{'name': cluster, 'database_engine': 'Atomic()'}
+                            for cluster in os.environ.get('DBT_CH_TEST_REMOTE_CLUSTERS', '').split(',')]
     test_db_engine = os.environ.get('DBT_CH_TEST_DB_ENGINE', '')
     test_secure = test_port in (8443, 9440)
     test_cluster_mode = os.environ.get('DBT_CH_TEST_CLUSTER_MODE', '').lower() in (
@@ -63,7 +64,7 @@ def test_config(ch_test_users, ch_test_version):
             if up_result[0]:
                 raise Exception(f'Failed to start docker: {up_result[2]}')
             url = f"http://{test_host}:{client_port}"
-            wait_until_responsive(timeout=30.0, pause=0.5, check=lambda: is_responsive(url))
+            wait_until_responsive(timeout=15.0, pause=0.5, check=lambda: is_responsive(url))
         except Exception as e:
             raise Exception(f'Failed to run docker compose: {e}')
     elif not client_port:

--- a/tests/integration/docker-compose.test_replica.yml
+++ b/tests/integration/docker-compose.test_replica.yml
@@ -1,0 +1,45 @@
+services:
+  ch0:
+    extends:
+      file: docker-compose.yml
+      service: clickhouse
+    environment:
+      - SERVER_INDEX=1
+      - SHARD_NUM=1
+      - REPLICA_NUM=1
+    ports:
+      - "8123:8123"
+      - "8443:8443"
+      - "9000:9000"
+      #  for local docker tests
+      - "10723:8123"
+      - "10743:8443"
+      - "10900:9000"
+  ch1:
+    extends:
+      file: docker-compose.yml
+      service: clickhouse
+    environment:
+      - SERVER_INDEX=2
+      - SHARD_NUM=1
+      - REPLICA_NUM=2
+  ch2:
+    extends:
+      file: docker-compose.yml
+      service: clickhouse
+    environment:
+      - SERVER_INDEX=3
+      - SHARD_NUM=1
+      - REPLICA_NUM=3
+  ch3:
+    extends:
+      file: docker-compose.yml
+      service: clickhouse-remote
+    environment:
+      - SERVER_INDEX=1
+      - SHARD_NUM=1
+      - REPLICA_NUM=1
+
+networks:
+  default:
+    name: integration-test

--- a/tests/integration/docker-compose.test_replica.yml
+++ b/tests/integration/docker-compose.test_replica.yml
@@ -40,9 +40,9 @@ services:
       - SHARD_NUM=1
       - REPLICA_NUM=1
     ports:
-      - "8124:8123"
+      - "8124:8124"
       - "8445:8443"
-      - "9001:9000"
+      - "9001:9001"
 
 networks:
   default:

--- a/tests/integration/docker-compose.test_replica.yml
+++ b/tests/integration/docker-compose.test_replica.yml
@@ -39,6 +39,10 @@ services:
       - SERVER_INDEX=1
       - SHARD_NUM=1
       - REPLICA_NUM=1
+    ports:
+      - "8124:8123"
+      - "8445:8443"
+      - "9001:9000"
 
 networks:
   default:

--- a/tests/integration/docker-compose.test_shard.yml
+++ b/tests/integration/docker-compose.test_shard.yml
@@ -1,0 +1,45 @@
+services:
+  ch0:
+    extends:
+      file: docker-compose.yml
+      service: clickhouse
+    environment:
+      - SERVER_INDEX=1
+      - SHARD_NUM=1
+      - REPLICA_NUM=1
+    ports:
+      - "8123:8123"
+      - "8443:8443"
+      - "9000:9000"
+      #  for local docker tests
+      - "10723:8123"
+      - "10743:8443"
+      - "10900:9000"
+  ch1:
+    extends:
+      file: docker-compose.yml
+      service: clickhouse
+    environment:
+      - SERVER_INDEX=2
+      - SHARD_NUM=2
+      - REPLICA_NUM=1
+  ch2:
+    extends:
+      file: docker-compose.yml
+      service: clickhouse
+    environment:
+      - SERVER_INDEX=3
+      - SHARD_NUM=3
+      - REPLICA_NUM=1
+  ch3:
+    extends:
+      file: docker-compose.yml
+      service: clickhouse-remote
+    environment:
+      - SERVER_INDEX=1
+      - SHARD_NUM=1
+      - REPLICA_NUM=1
+
+networks:
+  default:
+    name: integration-test

--- a/tests/integration/docker-compose.test_shard.yml
+++ b/tests/integration/docker-compose.test_shard.yml
@@ -40,9 +40,9 @@ services:
       - SHARD_NUM=1
       - REPLICA_NUM=1
     ports:
-      - "8124:8123"
+      - "8124:8124"
       - "8445:8443"
-      - "9001:9000"
+      - "9001:9001"
 
 networks:
   default:

--- a/tests/integration/docker-compose.test_shard.yml
+++ b/tests/integration/docker-compose.test_shard.yml
@@ -39,6 +39,10 @@ services:
       - SERVER_INDEX=1
       - SHARD_NUM=1
       - REPLICA_NUM=1
+    ports:
+      - "8124:8123"
+      - "8445:8443"
+      - "9001:9000"
 
 networks:
   default:

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -2,49 +2,32 @@
 version: '3'
 
 x-ch-common: &ch-common
+  image: clickhouse/clickhouse-server:${DBT_CH_TEST_CH_VERSION:-latest}
   volumes:
     - /var/lib/clickhouse
     - type: bind
       source: ${PROJECT_ROOT:-.}/test_settings_${DBT_CH_TEST_SETTINGS:-latest}.xml
       target: /etc/clickhouse-server/users.d/test_settings.xml
-    - type: bind
-      source: ${PROJECT_ROOT:-.}/test_config.xml
-      target: /etc/clickhouse-server/config.d/test_config.xml
   ulimits:
     nofile:
       soft: 262144
       hard: 262144
 
 services:
-  ch0:
-    image: clickhouse/clickhouse-server:${DBT_CH_TEST_CH_VERSION:-latest}
-    environment:
-      - SERVER_INDEX=1
-      - SHARD_NUM=${SHARD_NUM:-1}
-      - REPLICA_NUM=${REPLICA_NUM:-1}
-    ports:
-      - "8123:8123"
-      - "8443:8443"
-      - "9000:9000"
-      #  for local docker tests
-      - "10723:8123"
-      - "10743:8443"
-      - "10900:9000"
+  clickhouse:
     <<: *ch-common
-  ch1:
-    image: clickhouse/clickhouse-server:${DBT_CH_TEST_CH_VERSION:-latest}
-    environment:
-      - SERVER_INDEX=2
-      - SHARD_NUM=${SHARD_NUM:-2}
-      - REPLICA_NUM=${REPLICA_NUM:-2}
+    volumes:
+      - type: bind
+        source: ${PROJECT_ROOT:-.}/test_config.xml
+        target: /etc/clickhouse-server/config.d/test_config.xml
+
+  clickhouse-remote:
     <<: *ch-common
-  ch2:
-    image: clickhouse/clickhouse-server:${DBT_CH_TEST_CH_VERSION:-latest}
-    environment:
-      - SERVER_INDEX=3
-      - SHARD_NUM=${SHARD_NUM:-3}
-      - REPLICA_NUM=${REPLICA_NUM:-3}
-    <<: *ch-common
+    volumes:
+      - type: bind
+        source: ${PROJECT_ROOT:-.}/test_config.xml
+        target: /etc/clickhouse-server/config.d/test_config_remote.xml
+
 
 networks:
   default:

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -25,10 +25,5 @@ services:
     <<: *ch-common
     volumes:
       - type: bind
-        source: ${PROJECT_ROOT:-.}/test_config.xml
+        source: ${PROJECT_ROOT:-.}/test_config_remote.xml
         target: /etc/clickhouse-server/config.d/test_config_remote.xml
-
-
-networks:
-  default:
-    name: integration-test

--- a/tests/integration/test_config.xml
+++ b/tests/integration/test_config.xml
@@ -44,6 +44,14 @@
                 </replica>
             </shard>
         </test_replica>
+        <test_remote_cluster>
+            <shard>
+                <replica>
+                    <host>ch3</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_remote_cluster>
     </remote_servers>
     <keeper_server>
         <tcp_port>9181</tcp_port>

--- a/tests/integration/test_config_remote.xml
+++ b/tests/integration/test_config_remote.xml
@@ -1,6 +1,6 @@
 <clickhouse>
-    <http_port>8123</http_port>
-    <tcp_port>9000</tcp_port>
+    <http_port>8124</http_port>
+    <tcp_port>9001</tcp_port>
     <interserver_http_port>9009</interserver_http_port>
     <macros>
         <shard from_env="SHARD_NUM" />
@@ -12,7 +12,7 @@
             <shard>
                 <replica>
                     <host>ch3</host>
-                    <port>9000</port>
+                    <port>9001</port>
                 </replica>
             </shard>
         </test_remote_cluster>

--- a/tests/integration/test_config_remote.xml
+++ b/tests/integration/test_config_remote.xml
@@ -1,0 +1,43 @@
+<clickhouse>
+    <http_port>8123</http_port>
+    <tcp_port>9000</tcp_port>
+    <interserver_http_port>9009</interserver_http_port>
+    <macros>
+        <shard from_env="SHARD_NUM" />
+        <replica from_env="REPLICA_NUM" />
+        <server_index from_env="SERVER_INDEX" />
+    </macros>
+    <remote_servers>
+        <test_remote_cluster>
+            <shard>
+                <replica>
+                    <host>ch3</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_remote_cluster>
+    </remote_servers>
+    <keeper_server>
+        <tcp_port>9181</tcp_port>
+        <server_id from_env="SERVER_INDEX" />
+
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>30000</session_timeout_ms>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>ch3</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+    <zookeeper>
+        <node index="1">
+            <host>ch3</host>
+            <port>9181</port>
+        </node>
+    </zookeeper>
+</clickhouse>


### PR DESCRIPTION
**pr contains**
1. implements creation of remote (distributed) tables by providing a `remote_clusters` section in the profile target such as following:
```
clickhouse:
  target: test
  outputs:
    test:
      type: clickhouse
      ...
      remote_clusters:
        - name: cluster02
          database_engine: Replicated('/clickhouse/databases/{uuid}', '{shard}', '{replica}')
        - name: cluster03
```

2. fixes current issues with existing `database_engine` profile target credential

currently work in following cases:
- when current cluster db engine is `Atomic` and remote cluster db engine is `Atomic`
- when current cluster db engine is `Replicated` and remote cluster db engine is `Atomic`

not supported by this mr:
- remote cluster db engine is `Replicated`
- checking existing database engines (if exists, engine is just ignored)

**how to test this pr**
1. setup environment as described in `CONTRIBUTING.MD`
2. create the following .env file:
```
DBT_CH_TEST_USE_DOCKER=True
DBT_CH_TEST_CLUSTER_MODE=True
DBT_CH_TEST_CLUSTER=test_shard
DBT_CH_TEST_REMOTE_CLUSTERS=test_remote_cluster
```
3. run `pytest tests/integration/adapter/remote_clusters/.`